### PR TITLE
[bugfix] fix some problems when testing the SchemaRegistryClient

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/schema/registry/common/model/AuditInfo.java
+++ b/common/src/main/java/org/apache/rocketmq/schema/registry/common/model/AuditInfo.java
@@ -24,6 +24,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 
 @Data
 @EqualsAndHashCode(callSuper = false)
@@ -46,8 +47,13 @@ public class AuditInfo implements Serializable {
         this.createdTime = this.lastModifiedTime = new Date(System.currentTimeMillis());
     }
 
-    public void updateBy(String user) {
-        this.lastModifiedBy = user;
+    public void updateBy(String user, String desc) {
+        if (StringUtils.isNotBlank(user)) {
+            this.lastModifiedBy = user;
+        }
+        if (StringUtils.isNotBlank(desc)) {
+            this.desc = desc;
+        }
         this.lastModifiedTime = new Date(System.currentTimeMillis());
     }
 }

--- a/common/src/main/java/org/apache/rocketmq/schema/registry/common/model/SchemaInfo.java
+++ b/common/src/main/java/org/apache/rocketmq/schema/registry/common/model/SchemaInfo.java
@@ -43,8 +43,6 @@ public class SchemaInfo extends BaseInfo {
 
     private Map<String, String> extras = new HashMap<>();
 
-    private Boolean deleted;
-
     public SchemaInfo(final QualifiedName qualifiedName,
         final AuditInfo audit,
         final SchemaMetaInfo meta,
@@ -104,13 +102,5 @@ public class SchemaInfo extends BaseInfo {
         if (getAudit() != null) {
             getAudit().setLastModifiedTime(date);
         }
-    }
-
-    public Boolean getDeleted() {
-        return deleted;
-    }
-
-    public void setDeleted(Boolean deleted) {
-        this.deleted = deleted;
     }
 }

--- a/common/src/main/java/org/apache/rocketmq/schema/registry/common/model/SchemaInfo.java
+++ b/common/src/main/java/org/apache/rocketmq/schema/registry/common/model/SchemaInfo.java
@@ -43,6 +43,8 @@ public class SchemaInfo extends BaseInfo {
 
     private Map<String, String> extras = new HashMap<>();
 
+    private Boolean deleted;
+
     public SchemaInfo(final QualifiedName qualifiedName,
         final AuditInfo audit,
         final SchemaMetaInfo meta,
@@ -96,5 +98,19 @@ public class SchemaInfo extends BaseInfo {
 
     public Date getLastModifiedTime() {
         return getAudit() != null ? getAudit().getLastModifiedTime() : null;
+    }
+
+    public void setLastModifiedTime(Date date) {
+        if (getAudit() != null) {
+            getAudit().setLastModifiedTime(date);
+        }
+    }
+
+    public Boolean getDeleted() {
+        return deleted;
+    }
+
+    public void setDeleted(Boolean deleted) {
+        this.deleted = deleted;
     }
 }

--- a/common/src/main/java/org/apache/rocketmq/schema/registry/common/utils/CommonUtil.java
+++ b/common/src/main/java/org/apache/rocketmq/schema/registry/common/utils/CommonUtil.java
@@ -254,7 +254,7 @@ public class CommonUtil {
                     existing.add(new Schema.Parser().parse(current.getLastRecordIdl()));
                     validator.validate(toValidate, existing);
                 } catch (SchemaValidationException e) {
-                    throw new SchemaCompatibilityException("Schema validation failed", e);
+                    throw new SchemaCompatibilityException("Schema compatibility validation failed", e);
                 }
                 break;
             default:

--- a/core/src/main/java/org/apache/rocketmq/schema/registry/core/service/SchemaServiceImpl.java
+++ b/core/src/main/java/org/apache/rocketmq/schema/registry/core/service/SchemaServiceImpl.java
@@ -139,7 +139,7 @@ public class SchemaServiceImpl implements SchemaService<SchemaDto> {
 
         SchemaInfo current = storageServiceProxy.get(qualifiedName);
         if (current == null) {
-            throw new SchemaNotFoundException("Schema " + qualifiedName.toString() + " not exist, ignored update.");
+            throw new SchemaNotFoundException("Schema " + qualifiedName.fullName() + " not exist, ignored update.");
         }
 
         final SchemaRecordInfo updateRecord = new SchemaRecordInfo();
@@ -201,7 +201,7 @@ public class SchemaServiceImpl implements SchemaService<SchemaDto> {
 
         SchemaRecordInfo current = storageServiceProxy.getBySubject(qualifiedName);
         if (current == null) {
-            throw new SchemaNotFoundException("Schema " + qualifiedName.toString() + " not exist, ignored update.");
+            throw new SchemaNotFoundException("Schema " + qualifiedName.fullName() + " not exist, ignored update.");
         }
 
         log.info("delete schema {}", qualifiedName);
@@ -244,7 +244,7 @@ public class SchemaServiceImpl implements SchemaService<SchemaDto> {
 
         SchemaRecordInfo recordInfo = storageServiceProxy.getBySubject(qualifiedName);
         if (recordInfo == null) {
-            throw new SchemaException("Subject: " + qualifiedName.toString() + " not exist");
+            throw new SchemaException("Subject: " + qualifiedName.fullName() + " not exist");
         }
 
         log.info("get schema by subject: {}", qualifiedName.getSubject());
@@ -260,7 +260,7 @@ public class SchemaServiceImpl implements SchemaService<SchemaDto> {
 
         List<SchemaRecordInfo> recordInfos = storageServiceProxy.listBySubject(qualifiedName);
         if (recordInfos == null) {
-            throw new SchemaException("Subject: " + qualifiedName.toString() + " not exist");
+            throw new SchemaException("Subject: " + qualifiedName.fullName() + " not exist");
         }
 
         log.info("list schema by subject: {}", qualifiedName.getSubject());

--- a/core/src/main/java/org/apache/rocketmq/schema/registry/core/service/SchemaServiceImpl.java
+++ b/core/src/main/java/org/apache/rocketmq/schema/registry/core/service/SchemaServiceImpl.java
@@ -139,10 +139,8 @@ public class SchemaServiceImpl implements SchemaService<SchemaDto> {
 
         SchemaInfo current = storageServiceProxy.get(qualifiedName);
         if (current == null) {
-            throw new SchemaNotFoundException("Schema " + qualifiedName + " not exist, ignored update.");
+            throw new SchemaNotFoundException("Schema " + qualifiedName.toString() + " not exist, ignored update.");
         }
-
-        current.getAudit().updateBy(updateSchemaRequest.getOwner());
 
         final SchemaRecordInfo updateRecord = new SchemaRecordInfo();
         updateRecord.setSchema(qualifiedName.schemaFullName());
@@ -170,8 +168,13 @@ public class SchemaServiceImpl implements SchemaService<SchemaDto> {
             update.setStorage(current.getStorage());
         }
 
-        if (update.getExtras() != null) {
+        if (current.getExtras() != null) {
             update.setExtras(current.getExtras());
+        }
+
+        if (current.getAudit() != null) {
+            update.setAudit(current.getAudit());
+            update.getAudit().updateBy(updateSchemaRequest.getOwner(), updateSchemaRequest.getDesc());
         }
 
         CommonUtil.validateCompatibility(update, current, current.getMeta().getCompatibility());
@@ -198,7 +201,7 @@ public class SchemaServiceImpl implements SchemaService<SchemaDto> {
 
         SchemaRecordInfo current = storageServiceProxy.getBySubject(qualifiedName);
         if (current == null) {
-            throw new SchemaNotFoundException("Schema " + qualifiedName + " not exist, ignored update.");
+            throw new SchemaNotFoundException("Schema " + qualifiedName.toString() + " not exist, ignored update.");
         }
 
         log.info("delete schema {}", qualifiedName);
@@ -241,7 +244,7 @@ public class SchemaServiceImpl implements SchemaService<SchemaDto> {
 
         SchemaRecordInfo recordInfo = storageServiceProxy.getBySubject(qualifiedName);
         if (recordInfo == null) {
-            throw new SchemaException("Subject: " + qualifiedName + " not exist");
+            throw new SchemaException("Subject: " + qualifiedName.toString() + " not exist");
         }
 
         log.info("get schema by subject: {}", qualifiedName.getSubject());
@@ -257,7 +260,7 @@ public class SchemaServiceImpl implements SchemaService<SchemaDto> {
 
         List<SchemaRecordInfo> recordInfos = storageServiceProxy.listBySubject(qualifiedName);
         if (recordInfos == null) {
-            throw new SchemaException("Subject: " + qualifiedName + " not exist");
+            throw new SchemaException("Subject: " + qualifiedName.toString() + " not exist");
         }
 
         log.info("list schema by subject: {}", qualifiedName.getSubject());

--- a/example/src/main/java/org/apache/rocketmq/schema/registry/example/DeleteSchemaDemo.java
+++ b/example/src/main/java/org/apache/rocketmq/schema/registry/example/DeleteSchemaDemo.java
@@ -35,10 +35,14 @@ public class DeleteSchemaDemo {
         try {
             DeleteSchemeResponse response
                 = schemaRegistryClient.deleteSchema("default", "default", topic, 2);
-            System.out.println("delete schema by version success, schemaId: " + response.getSchemaId());
+            System.out.println("delete schema by subject and version success, schemaId: " + response.getSchemaId());
 
             Thread.sleep(5000);
             System.out.println("current schema: " + schemaRegistryClient.getSchemaBySubject(topic));
+
+            DeleteSchemeResponse response1
+                = schemaRegistryClient.deleteSchema("default", "default", topic);
+            System.out.println("delete schema by subject success, schemaId: " + response1.getSchemaId());
         } catch (RestClientException | IOException | InterruptedException e) {
             e.printStackTrace();
         }

--- a/storage-rocketmq/src/main/java/org/apache/rocketmq/schema/registry/storage/rocketmq/RocketmqClient.java
+++ b/storage-rocketmq/src/main/java/org/apache/rocketmq/schema/registry/storage/rocketmq/RocketmqClient.java
@@ -31,7 +31,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang3.BooleanUtils;
 import org.apache.rocketmq.client.consumer.DefaultLitePullConsumer;
 import org.apache.rocketmq.client.exception.MQClientException;
 import org.apache.rocketmq.client.producer.DefaultMQProducer;

--- a/storage-rocketmq/src/main/java/org/apache/rocketmq/schema/registry/storage/rocketmq/configs/RocketmqConfigConstants.java
+++ b/storage-rocketmq/src/main/java/org/apache/rocketmq/schema/registry/storage/rocketmq/configs/RocketmqConfigConstants.java
@@ -48,6 +48,4 @@ public class RocketmqConfigConstants {
     public static final byte[] STORAGE_ROCKSDB_SCHEMA_COLUMN_FAMILY = "schema".getBytes(StandardCharsets.UTF_8);
     public static final byte[] STORAGE_ROCKSDB_SUBJECT_COLUMN_FAMILY = "subject".getBytes(StandardCharsets.UTF_8);
 
-    public static final String DELETE_KEYS = "%DEL%";
-
 }

--- a/storage-rocketmq/src/main/java/org/apache/rocketmq/schema/registry/storage/rocketmq/configs/RocketmqConfigConstants.java
+++ b/storage-rocketmq/src/main/java/org/apache/rocketmq/schema/registry/storage/rocketmq/configs/RocketmqConfigConstants.java
@@ -48,4 +48,5 @@ public class RocketmqConfigConstants {
     public static final byte[] STORAGE_ROCKSDB_SCHEMA_COLUMN_FAMILY = "schema".getBytes(StandardCharsets.UTF_8);
     public static final byte[] STORAGE_ROCKSDB_SUBJECT_COLUMN_FAMILY = "subject".getBytes(StandardCharsets.UTF_8);
 
+    public static final String DELETE_KEYS = "deleted";
 }


### PR DESCRIPTION
bug1: When updating the schema, the audit info will be lost.

bug2: When throwing SchemaNotFoundException, the massage cannot be parsed to JSON.

bug3: After delete the schema by subject, we will send a message with _DELETE_KEY_ so that the local cache can be refreshed. But when the registry server restart and the local cache replay, maybe we will consume the _DELETE_KEY_ massage first and then consume the schema message, thus the deleted schema will regenerate in local cache, inconsistent with remote storage.