### PR TITLE
Fix: Avro serde should support T extends record except a specific record type

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/schema/registry/client/serde/avro/GenericAvroDeserializer.java
+++ b/client/src/main/java/org/apache/rocketmq/schema/registry/client/serde/avro/GenericAvroDeserializer.java
@@ -22,8 +22,8 @@ import org.apache.rocketmq.schema.registry.client.serde.Deserializer;
 
 import java.util.Map;
 
-public class GenericAvroDeserializer implements Deserializer<GenericRecord> {
-    private final AvroDeserializer<GenericRecord> inner;
+public class GenericAvroDeserializer<T extends GenericRecord> implements Deserializer<T> {
+    private final AvroDeserializer<T> inner;
 
     public GenericAvroDeserializer() {
         this.inner = new AvroDeserializer<>();
@@ -39,7 +39,7 @@ public class GenericAvroDeserializer implements Deserializer<GenericRecord> {
     }
 
     @Override
-    public GenericRecord deserialize(String subject, byte[] bytes) {
+    public T deserialize(String subject, byte[] bytes) {
         return this.inner.deserialize(subject, bytes);
     }
 

--- a/client/src/main/java/org/apache/rocketmq/schema/registry/client/serde/avro/GenericAvroSerde.java
+++ b/client/src/main/java/org/apache/rocketmq/schema/registry/client/serde/avro/GenericAvroSerde.java
@@ -25,13 +25,13 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.Map;
 
-public class GenericAvroSerde implements Closeable {
-    private final Serializer<GenericRecord> serializer;
-    private final Deserializer<GenericRecord> deserializer;
+public class GenericAvroSerde<T extends GenericRecord> implements Closeable {
+    private final Serializer<T> serializer;
+    private final Deserializer<T> deserializer;
 
     public GenericAvroSerde() {
-        this.serializer = new GenericAvroSerializer();
-        this.deserializer = new GenericAvroDeserializer();
+        this.serializer = new GenericAvroSerializer<T>();
+        this.deserializer = new GenericAvroDeserializer<T>();
     }
 
     public GenericAvroSerde(final SchemaRegistryClient client) {
@@ -47,11 +47,11 @@ public class GenericAvroSerde implements Closeable {
         this.deserializer.configure(configs);
     }
 
-    public Serializer<GenericRecord> serializer() {
+    public Serializer<T> serializer() {
         return this.serializer;
     }
 
-    public Deserializer<GenericRecord> deserializer() {
+    public Deserializer<T> deserializer() {
         return this.deserializer;
     }
 

--- a/client/src/main/java/org/apache/rocketmq/schema/registry/client/serde/avro/GenericAvroSerializer.java
+++ b/client/src/main/java/org/apache/rocketmq/schema/registry/client/serde/avro/GenericAvroSerializer.java
@@ -22,16 +22,16 @@ import org.apache.rocketmq.schema.registry.client.serde.Serializer;
 
 import java.util.Map;
 
-public class GenericAvroSerializer implements Serializer<GenericRecord> {
+public class GenericAvroSerializer<T extends GenericRecord> implements Serializer<T> {
 
-    private final AvroSerializer<GenericRecord> inner;
+    private final AvroSerializer<T> inner;
 
     public GenericAvroSerializer() {
-        this.inner = new AvroSerializer<GenericRecord>();
+        this.inner = new AvroSerializer<T>();
     }
 
     public GenericAvroSerializer(final SchemaRegistryClient client) {
-        this.inner = new AvroSerializer<GenericRecord>(client);
+        this.inner = new AvroSerializer<T>(client);
     }
     @Override
     public void configure(final Map<String, Object> configs) {
@@ -39,7 +39,7 @@ public class GenericAvroSerializer implements Serializer<GenericRecord> {
     }
 
     @Override
-    public byte[] serialize(final String subject, final GenericRecord record) {
+    public byte[] serialize(final String subject, final T record) {
         return this.inner.serialize(subject, record);
     }
 

--- a/client/src/main/java/org/apache/rocketmq/schema/registry/client/serde/avro/SpecificAvroDeserializer.java
+++ b/client/src/main/java/org/apache/rocketmq/schema/registry/client/serde/avro/SpecificAvroDeserializer.java
@@ -22,7 +22,7 @@ import org.apache.rocketmq.schema.registry.client.serde.Deserializer;
 
 import java.util.Map;
 
-public class SpecificAvroDeserializer implements Deserializer<SpecificRecord> {
+public class SpecificAvroDeserializer<T extends SpecificRecord> implements Deserializer<T> {
 
     private final AvroDeserializer<SpecificRecord> inner;
 
@@ -39,9 +39,10 @@ public class SpecificAvroDeserializer implements Deserializer<SpecificRecord> {
         this.inner.configure(configs);
     }
 
+    @SuppressWarnings("unchecked")
     @Override
-    public SpecificRecord deserialize(String subject, byte[] bytes) {
-        return this.inner.deserialize(subject, bytes);
+    public T deserialize(String subject, byte[] bytes) {
+        return (T) this.inner.deserialize(subject, bytes);
     }
 
     @Override

--- a/client/src/main/java/org/apache/rocketmq/schema/registry/client/serde/avro/SpecificAvroSerde.java
+++ b/client/src/main/java/org/apache/rocketmq/schema/registry/client/serde/avro/SpecificAvroSerde.java
@@ -25,9 +25,9 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.Map;
 
-public class SpecificAvroSerde implements Closeable {
-    private final AvroSerializer<SpecificRecord> serializer;
-    private final AvroDeserializer<SpecificRecord> deserializer;
+public class SpecificAvroSerde<T extends SpecificRecord> implements Closeable {
+    private final AvroSerializer<T> serializer;
+    private final AvroDeserializer<T> deserializer;
 
     public SpecificAvroSerde() {
         this.serializer = new AvroSerializer<>();
@@ -43,11 +43,11 @@ public class SpecificAvroSerde implements Closeable {
         this.deserializer = new AvroDeserializer<>(client);
     }
 
-    public Serializer<SpecificRecord> serializer() {
+    public Serializer<T> serializer() {
         return this.serializer;
     }
 
-    public Deserializer<SpecificRecord> deserializer() {
+    public Deserializer<T> deserializer() {
         return this.deserializer;
     }
 

--- a/client/src/main/java/org/apache/rocketmq/schema/registry/client/serde/avro/SpecificAvroSerializer.java
+++ b/client/src/main/java/org/apache/rocketmq/schema/registry/client/serde/avro/SpecificAvroSerializer.java
@@ -16,15 +16,14 @@
  */
 package org.apache.rocketmq.schema.registry.client.serde.avro;
 
-import org.apache.avro.specific.SpecificRecord;
 import org.apache.rocketmq.schema.registry.client.SchemaRegistryClient;
 import org.apache.rocketmq.schema.registry.client.serde.Serializer;
 
 import java.util.Map;
 
-public class SpecificAvroSerializer implements Serializer<SpecificRecord> {
+public class SpecificAvroSerializer<T> implements Serializer<T> {
 
-    private final AvroSerializer<SpecificRecord> inner;
+    private final AvroSerializer<T> inner;
 
     public SpecificAvroSerializer() {
         this.inner = new AvroSerializer<>();
@@ -40,7 +39,7 @@ public class SpecificAvroSerializer implements Serializer<SpecificRecord> {
     }
 
     @Override
-    public byte[] serialize(String subject, SpecificRecord record) {
+    public byte[] serialize(String subject, T record) {
         return this.inner.serialize(subject, record);
     }
 

--- a/client/src/test/java/org/apache/rocketmq/schema/registry/client/serde/avro/GenericAvroSerdeTest.java
+++ b/client/src/test/java/org/apache/rocketmq/schema/registry/client/serde/avro/GenericAvroSerdeTest.java
@@ -69,7 +69,7 @@ public class GenericAvroSerdeTest {
             byte[] bytes = serde.serializer().serialize("TopicTest", record);
 
             //deserialize
-            GenericRecord record1 = serde.deserializer().deserialize("TopicTest", bytes);
+            GenericRecord record1 = (GenericRecord) serde.deserializer().deserialize("TopicTest", bytes);
             assertThat(record1).isEqualTo(record);
         } catch (IOException e) {
             System.out.println("serde shutdown failed");

--- a/example/src/main/java/org/apache/rocketmq/schema/registry/example/serde/avro/GenericAvroSerdeDemo.java
+++ b/example/src/main/java/org/apache/rocketmq/schema/registry/example/serde/avro/GenericAvroSerdeDemo.java
@@ -41,7 +41,7 @@ public class GenericAvroSerdeDemo {
                 .set("amount", 100.0)
                 .build();
 
-        try (GenericAvroSerde serde = new GenericAvroSerde(schemaRegistryClient)) {
+        try (GenericAvroSerde<GenericRecord> serde = new GenericAvroSerde<>(schemaRegistryClient)) {
             //configure
             Map<String, Object> configs = new HashMap<>();
             configs.put(AvroSerializerConfig.USE_GENERIC_DATUM_READER, true);

--- a/example/src/main/java/org/apache/rocketmq/schema/registry/example/serde/avro/SpecificAvroSerdeDemo.java
+++ b/example/src/main/java/org/apache/rocketmq/schema/registry/example/serde/avro/SpecificAvroSerdeDemo.java
@@ -36,7 +36,7 @@ public class SpecificAvroSerdeDemo {
         Map<String, Object> serializeConfigs = new HashMap<>();
 
 
-        try (SpecificAvroSerde serde = new SpecificAvroSerde(schemaRegistryClient)) {
+        try (SpecificAvroSerde<Charge> serde = new SpecificAvroSerde<Charge>(schemaRegistryClient)) {
 
             //serialize
             Charge charge = new Charge("specific", 100.0);
@@ -46,7 +46,7 @@ public class SpecificAvroSerdeDemo {
             byte[] bytes = serde.serializer().serialize("TopicTest", charge);
 
             //deserialize
-            Charge charge1 = (Charge) serde.deserializer().deserialize("TopicTest", bytes);
+            Charge charge1 = serde.deserializer().deserialize("TopicTest", bytes);
             System.out.println("the origin object after ser/de is " + charge1);
         } catch (IOException e) {
             System.out.println("serde shutdown failed");


### PR DESCRIPTION
Avro Ser/de should serialize a type T that extends record type and deserializer should return  type T except a specific record type.