### PR TITLE
add list tenants rest interface to support flink list databases

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/schema/registry/client/NormalSchemaRegistryClient.java
+++ b/client/src/main/java/org/apache/rocketmq/schema/registry/client/NormalSchemaRegistryClient.java
@@ -102,4 +102,9 @@ public class NormalSchemaRegistryClient implements SchemaRegistryClient {
         return restService.getSubjectsByTenant(cluster, tenant);
     }
 
+    @Override
+    public List<String> getAllTenants(String cluster) throws RestClientException, IOException {
+        return restService.getAllTenants(cluster);
+    }
+
 }

--- a/client/src/main/java/org/apache/rocketmq/schema/registry/client/SchemaRegistryClient.java
+++ b/client/src/main/java/org/apache/rocketmq/schema/registry/client/SchemaRegistryClient.java
@@ -60,4 +60,5 @@ public interface SchemaRegistryClient {
 
     List<String> getSubjectsByTenant(String cluster, String tenant) throws RestClientException, IOException;
 
+    List<String> getAllTenants(String cluster) throws RestClientException, IOException;
 }

--- a/client/src/main/java/org/apache/rocketmq/schema/registry/client/rest/RestService.java
+++ b/client/src/main/java/org/apache/rocketmq/schema/registry/client/rest/RestService.java
@@ -50,7 +50,7 @@ public class RestService {
     private static final TypeReference<List<SchemaRecordDto>> SCHEMA_RECORD_DTO_TYPE_LIST_REFERENCE =
         new TypeReference<List<SchemaRecordDto>>() { };
 
-    private static final TypeReference<List<String>> GET_SUBJECTS_REFERENCE =
+    private static final TypeReference<List<String>> LIST_STRING_REFERENCE =
         new TypeReference<List<String>>() { };
 
     public static ObjectMapper jsonParser = JacksonMapper.INSTANCE;
@@ -150,6 +150,12 @@ public class RestService {
     public List<String> getSubjectsByTenant(String cluster, String tenant) throws RestClientException, IOException {
         UrlBuilder urlBuilder = UrlBuilder.fromPath("/cluster/{cluster-name}/tenant/{tenant-name}/subjects");
         String path = HttpUtil.buildRequestUrl(baseUri, urlBuilder.build(cluster, tenant).toString());
-        return HttpUtil.sendHttpRequest(path, HTTP_GET, null, httpHeaders, GET_SUBJECTS_REFERENCE);
+        return HttpUtil.sendHttpRequest(path, HTTP_GET, null, httpHeaders, LIST_STRING_REFERENCE);
+    }
+
+    public List<String> getAllTenants(String cluster) throws RestClientException, IOException {
+        UrlBuilder urlBuilder = UrlBuilder.fromPath("/cluster/{cluster-name}/tenants");
+        String path = HttpUtil.buildRequestUrl(baseUri, urlBuilder.build(cluster).toString());
+        return HttpUtil.sendHttpRequest(path, HTTP_GET, null, httpHeaders, LIST_STRING_REFERENCE);
     }
 }

--- a/common/src/main/java/org/apache/rocketmq/schema/registry/common/storage/StorageService.java
+++ b/common/src/main/java/org/apache/rocketmq/schema/registry/common/storage/StorageService.java
@@ -87,4 +87,8 @@ public interface StorageService<T extends BaseInfo> {
     default List<String> listSubjectsByTenant(StorageServiceContext storageServiceContext, QualifiedName name) {
         throw new UnsupportedOperationException(ERROR_MESSAGE_DEFAULT);
     }
+
+    default List<String> listTenants(StorageServiceContext storageService, QualifiedName name) {
+        throw new UnsupportedOperationException(ERROR_MESSAGE_DEFAULT);
+    }
 }

--- a/common/src/main/java/org/apache/rocketmq/schema/registry/common/storage/StorageServiceProxy.java
+++ b/common/src/main/java/org/apache/rocketmq/schema/registry/common/storage/StorageServiceProxy.java
@@ -121,4 +121,12 @@ public class StorageServiceProxy {
 
         return storageService.listSubjectsByTenant(storageServiceContext, name);
     }
+
+    public List<String> listTenants(final QualifiedName name) {
+        final RequestContext requestContext = RequestContextManager.getContext();
+        final StorageServiceContext storageServiceContext = storageUtil.convertToStorageServiceContext(requestContext);
+        final StorageService<SchemaInfo> storageService = storageManager.getStorageService();
+
+        return storageService.listTenants(storageServiceContext, name);
+    }
 }

--- a/core/src/main/java/org/apache/rocketmq/schema/registry/core/api/v1/SchemaController.java
+++ b/core/src/main/java/org/apache/rocketmq/schema/registry/core/api/v1/SchemaController.java
@@ -463,8 +463,29 @@ public class SchemaController {
         QualifiedName name = new QualifiedName(cluster, tenant, null, null);
 
         return this.requestProcessor.processRequest(
-                "getSubjectListByTenant",
+            "getSubjectListByTenant",
             () -> schemaService.listSubjectsByTenant(name)
+        );
+    }
+
+
+    @RequestMapping(
+            method = RequestMethod.GET,
+            path =  "/cluster/{cluster-name}/tenants"
+        )
+    @ApiOperation(
+            value = "tenants list",
+            notes = "all tenant from cluster"
+        )
+    public List<String> getTenants(
+            @ApiParam(value = "The cluster of the tenant", required = true)
+            @PathVariable(value = "cluster-name") final String cluster
+    ) {
+        QualifiedName name = new QualifiedName(cluster, null, null, null);
+
+        return this.requestProcessor.processRequest(
+            "getTenants",
+            () -> schemaService.listTenants(name)
         );
     }
 }

--- a/core/src/main/java/org/apache/rocketmq/schema/registry/core/service/SchemaService.java
+++ b/core/src/main/java/org/apache/rocketmq/schema/registry/core/service/SchemaService.java
@@ -81,4 +81,6 @@ public interface SchemaService<T extends BaseDto> {
     List<SchemaRecordDto> listBySubject(QualifiedName qualifiedName);
 
     List<String> listSubjectsByTenant(QualifiedName qualifiedName);
+
+    List<String> listTenants(QualifiedName name);
 }

--- a/core/src/main/java/org/apache/rocketmq/schema/registry/core/service/SchemaServiceImpl.java
+++ b/core/src/main/java/org/apache/rocketmq/schema/registry/core/service/SchemaServiceImpl.java
@@ -288,6 +288,18 @@ public class SchemaServiceImpl implements SchemaService<SchemaDto> {
         return subjects;
     }
 
+    @Override
+    public List<String> listTenants(QualifiedName qualifiedName) {
+        final RequestContext requestContext = RequestContextManager.getContext();
+        log.info("get request context: " + requestContext);
+
+        this.accessController.checkPermission("", qualifiedName.getCluster(), SchemaOperation.GET);
+
+        List<String> tenants = storageServiceProxy.listTenants(qualifiedName);
+        log.info("list all tenants: {}", qualifiedName.getCluster());
+        return tenants;
+    }
+
     private void checkSchemaExist(final QualifiedName qualifiedName) {
         if (storageServiceProxy.get(qualifiedName) != null) {
             throw new SchemaExistException(qualifiedName);

--- a/storage-rocketmq/src/main/java/org/apache/rocketmq/schema/registry/storage/rocketmq/RocketmqClient.java
+++ b/storage-rocketmq/src/main/java/org/apache/rocketmq/schema/registry/storage/rocketmq/RocketmqClient.java
@@ -46,6 +46,7 @@ import org.apache.rocketmq.common.protocol.body.ClusterInfo;
 import org.apache.rocketmq.common.protocol.route.BrokerData;
 import org.apache.rocketmq.common.protocol.route.TopicRouteData;
 import org.apache.rocketmq.schema.registry.common.QualifiedName;
+import org.apache.rocketmq.schema.registry.common.constant.SchemaConstants;
 import org.apache.rocketmq.schema.registry.common.context.StorageServiceContext;
 import org.apache.rocketmq.schema.registry.common.exception.SchemaException;
 import org.apache.rocketmq.schema.registry.common.exception.SchemaExistException;
@@ -433,7 +434,7 @@ public class RocketmqClient {
         RocksIterator iterator = cache.newIterator(subjectCfHandle());
         for (iterator.seekToFirst(); iterator.isValid(); iterator.next()) {
             String subjectFullName = new String(iterator.key());
-            String[] subjectFromCache = subjectFullName.split("/");
+            String[] subjectFromCache = subjectFullName.split(String.valueOf(SchemaConstants.SUBJECT_SEPARATOR));
             String tenantFromKey = subjectFromCache[1];
             String subjectFromKey = subjectFromCache[2];
             if (isSuperAdmin(context.getUserName()) || tenant.equals(tenantFromKey)) {
@@ -441,6 +442,17 @@ public class RocketmqClient {
             }
         }
         return subjects;
+    }
+
+    public List<String> getTenants(String cluster) {
+        List<String> tenants = new ArrayList<>();
+        RocksIterator iterator = cache.newIterator(subjectCfHandle());
+        for (iterator.seekToFirst(); iterator.isValid(); iterator.next()) {
+            String subjectFullName = new String(iterator.key());
+            String tenant = subjectFullName.split(String.valueOf(SchemaConstants.SUBJECT_SEPARATOR))[1];
+            tenants.add(tenant);
+        }
+        return tenants;
     }
 
     private boolean isSuperAdmin(String userName) {

--- a/storage-rocketmq/src/main/java/org/apache/rocketmq/schema/registry/storage/rocketmq/RocketmqStorageClient.java
+++ b/storage-rocketmq/src/main/java/org/apache/rocketmq/schema/registry/storage/rocketmq/RocketmqStorageClient.java
@@ -84,5 +84,11 @@ public interface RocketmqStorageClient {
         throw new UnsupportedOperationException(ERROR_MESSAGE_DEFAULT);
     }
 
-    List<String> listSubjectsByTenant(StorageServiceContext context, QualifiedName name);
+    default List<String> listSubjectsByTenant(StorageServiceContext context, QualifiedName name) {
+        throw new UnsupportedOperationException(ERROR_MESSAGE_DEFAULT);
+    }
+
+    default List<String> listTenant(QualifiedName name) {
+        throw new UnsupportedOperationException(ERROR_MESSAGE_DEFAULT);
+    }
 }

--- a/storage-rocketmq/src/main/java/org/apache/rocketmq/schema/registry/storage/rocketmq/RocketmqStorageClientImpl.java
+++ b/storage-rocketmq/src/main/java/org/apache/rocketmq/schema/registry/storage/rocketmq/RocketmqStorageClientImpl.java
@@ -122,7 +122,13 @@ public class RocketmqStorageClientImpl implements RocketmqStorageClient {
         return schemaInfo.getDetails().getSchemaRecords();
     }
 
+    @Override
     public List<String> listSubjectsByTenant(StorageServiceContext context, QualifiedName qualifiedName) {
         return rocketmqClient.getSubjects(context, qualifiedName.getTenant());
+    }
+
+    @Override
+    public List<String> listTenant(QualifiedName qualifiedName) {
+        return rocketmqClient.getTenants(qualifiedName.getCluster());
     }
 }

--- a/storage-rocketmq/src/main/java/org/apache/rocketmq/schema/registry/storage/rocketmq/RocketmqStorageService.java
+++ b/storage-rocketmq/src/main/java/org/apache/rocketmq/schema/registry/storage/rocketmq/RocketmqStorageService.java
@@ -87,4 +87,8 @@ public class RocketmqStorageService implements StorageService<SchemaInfo> {
     public List<String> listSubjectsByTenant(StorageServiceContext context, QualifiedName name) {
         return storageClient.listSubjectsByTenant(context, name);
     }
+
+    public List<String> listTenants(StorageServiceContext storageService, QualifiedName name) {
+        return storageClient.listTenant(name);
+    }
 }


### PR DESCRIPTION
In schema registry's system and flink system, there are these corresponding relationships:
cluster <-> catalog
tenant(namespace) <-> database
subject <-> table

This pr's purpose is support flink list all databases.